### PR TITLE
feat: support x-http-status header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -351,7 +351,12 @@ export class Client {
         options.body = data
       }
     }
-    return Client.request(options)
+    return Client.request(options).then((resp) => {
+      if (resp.statusCode === 200 && Number(resp.headers['x-http-status']) > 0) {
+        resp.statusCode = Number(resp.headers['x-http-status'])
+      }
+      return resp
+    })
   }
 
   /**

--- a/test/index.ts
+++ b/test/index.ts
@@ -394,6 +394,39 @@ suite('tws-auth', function (this: Suite) {
     })
   })
 
+  suite('client.request with x-http-status', function () {
+    let server: http.Server
+    let cli: Client
+
+    before(function () {
+      server = http.createServer((_, res) => {
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json; charset=utf-8')
+        res.setHeader('x-http-status', '400')
+        res.end(JSON.stringify({
+          error: 'Bad Param Request',
+        }))
+      })
+      server.listen()
+      const addr = server.address() as AddressInfo
+
+      cli = new Client({
+        appId: '59294da476d70b4b83fa91a5',
+        appSecrets: ['123'],
+        host: `http://127.0.0.1:${addr.port}`,
+      })
+    })
+
+    after(function () {
+      server.close()
+    })
+
+    it('request should ok', async function () {
+      const res = await cli.request('GET', '/abc')
+      assert.equal(res.statusCode, 400)
+    })
+  })
+
   suite('auth service', function () {
     let cli: TWS
 


### PR DESCRIPTION
Use `x-http-status` as http status code to support some environment that only support http status code 200.