### PR TITLE
fix: 支持request useQuerystring 参数

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,7 @@ export interface ClientOptions {
   certChain?: Buffer
   privateKey?: Buffer
   rootCert?: string | Buffer | string[] | Buffer[]
+  useQuerystring?: boolean
 }
 
 export interface Payload { [key: string]: any }
@@ -150,6 +151,7 @@ export class Client {
       retryDelay: options.retryDelay,
       maxAttempts: options.maxAttempts,
       retryErrorCodes: options.retryErrorCodes,
+      useQuerystring: options.useQuerystring,
     } as RequestOptions
   }
 


### PR DESCRIPTION
tws 服务数据传递都是默认 `useQuerystring` 方式，所以默认设置为 true